### PR TITLE
Replacing uglify with terser

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -4,7 +4,7 @@ const browserSync = require('browser-sync').create();
 const sass = require('gulp-sass');
 const htmlmin = require('gulp-htmlmin');
 const cssmin = require('gulp-cssmin');
-const uglify = require('gulp-uglify');
+const terser = require("gulp-terser");
 const imagemin = require('gulp-imagemin');
 const concat = require('gulp-concat');
 const jsImport = require('gulp-js-import');
@@ -45,7 +45,7 @@ function js() {
             hideConsole: true
         }))
         .pipe(concat('all.js'))
-        .pipe(gulpIf(isProd, uglify()))
+        .pipe(gulpIf(isProd, terser()))
         .pipe(gulp.dest('docs/js'));
 }
 

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "gulp-js-import": "^1.0.6",
     "gulp-sass": "^4.0.2",
     "gulp-sourcemaps": "^2.6.5",
-    "gulp-uglify": "^3.0.2"
+    "gulp-terser": "^2.1.0"
   },
   "dependencies": {}
 }


### PR DESCRIPTION
I was having this error on a clean installation, running `npm run prod`

`GulpUglifyError: unable to minify JavaScript Caused by: SyntaxError: Unexpected token: keyword «const»`